### PR TITLE
Using the new geolocation database format.

### DIFF
--- a/geolocation.php
+++ b/geolocation.php
@@ -113,6 +113,21 @@ class geolocation extends rcube_plugin
             }
             break;
 
+	case 'maxminddb':
+	    $geo = array('city' => 'unknown', 'region'  => 'unknown','country' => '??');
+	    if (extension_loaded('maxminddb')) {
+        	$rcmail = rcube::get_instance();
+		$db_location = $rcmail->config->get('geolocation_db', '/usr/share/GeoIP/GeoLite2-City.mmdb');
+		if(!$db_location) break;
+		$reader = new \MaxMind\Db\Reader($db_location);
+		if(!$reader) break;
+		$rd = $reader->get($ip);
+		if(!$rd) break;
+		$geo = array(
+			'city' => utf8_encode($rd['city']['names']['en']),
+			'country' => utf8_encode($rd['country']['names']['en']));
+	    }
+	    break;
         case 'system':
         default:
             // using system database


### PR DESCRIPTION
The old geolocation database format that uses the "geoip" extension is
no longer supported for at least 3 years.
To use the new geolocation database format, you need to use the
libmaxminddb library (https://github.com/maxmind/libmaxminddb) and the
maxminddb extension (https://github.com/maxmind/MaxMind-DB-Reader-php.git) .

To use the new method, two parameters must be added to the configuration:

$config['geolocation_fetch_method'] = 'maxminddb';
$config['geolocation_db'] = '/usr/share/GeoIP/GeoLite2-City.mmdb';

Use https://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz
to update geolocation database information.